### PR TITLE
Refine Figplit for landing page focus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,33 @@
-[![Bolt Open Source Codebase](./public/social_preview_index.jpg)](https://bolt.new)
+[![Figplit Open Source Workspace](./public/social_preview_index.jpg)](https://bolt.new)
 
-> Welcome to the **Bolt** open-source codebase! This repo contains a simple example app using the core components from bolt.new to help you get started building **AI-powered software development tools** powered by StackBlitz’s **WebContainer API**.
+> Welcome to the **Figplit** open-source workspace! This repository keeps the Bolt.new foundations but reshapes them into an AI assistant obsessed with shipping iconic landing pages. If you want to extend Figplit, wire in new snippet packs, or tweak the agent’s behaviours, you’re in the right place.
 
-### Why Build with Bolt + WebContainer API
+### Why build with Figplit + WebContainer API
 
-By building with the Bolt + WebContainer API you can create browser-based applications that let users **prompt, run, edit, and deploy** full-stack web apps directly in the browser, without the need for virtual machines. With WebContainer API, you can build apps that give AI direct access and full control over a **Node.js server**, **filesystem**, **package manager** and **dev terminal** inside your users browser tab. This powerful combination allows you to create a new class of development tools that support all major JavaScript libraries and Node packages right out of the box, all without remote environments or local installs.
+StackBlitz’s WebContainer API still powers the entire experience: a browser-based environment where the AI can **prompt, edit, run, and preview** the project without any remote servers. Figplit layers a design-forward UX, curated motion snippets, and prompt guardrails that keep the agent focused on front-of-house experiences—hero sections, launch pages, pricing tables, and product demos.
 
-### What’s the Difference Between Bolt (This Repo) and [Bolt.new](https://bolt.new)?
+### What’s the difference between Figplit and Bolt.new?
 
-- **Bolt.new**: This is the **commercial product** from StackBlitz—a hosted, browser-based AI development tool that enables users to prompt, run, edit, and deploy full-stack web applications directly in the browser. Built on top of the [Bolt open-source repo](https://github.com/stackblitz/bolt.new) and powered by the StackBlitz **WebContainer API**.
+- **Bolt.new**: The original StackBlitz product for building any full-stack app in the browser.
+- **Figplit**: This fork narrows the scope to marketing and product landing pages, adding motion-aware onboarding, reusable design snippets, and instructions that push the LLM toward polish over raw functionality.
 
-- **Bolt (This Repo)**: This open-source repository provides the core components used to make **Bolt.new**. This repo contains the UI interface for Bolt as well as the server components, built using [Remix Run](https://remix.run/). By leveraging this repo and StackBlitz’s **WebContainer API**, you can create your own AI-powered development tools and full-stack applications that run entirely in the browser.
+# Build with Figplit
 
-# Get Started Building with Bolt
-
-Bolt combines the capabilities of AI with sandboxed development environments to create a collaborative experience where code can be developed by the assistant and the programmer together. Bolt combines [WebContainer API](https://webcontainers.io/api) with [Claude Sonnet 3.5](https://www.anthropic.com/news/claude-3-5-sonnet) using [Remix](https://remix.run/) and the [AI SDK](https://sdk.vercel.ai/).
+Figplit combines [WebContainer API](https://webcontainers.io/api) with [Claude Sonnet 3.5](https://www.anthropic.com/news/claude-3-5-sonnet), [Remix](https://remix.run/), and the [AI SDK](https://sdk.vercel.ai/) to orchestrate a conversational editing loop tailored to front-end storytelling.
 
 ### WebContainer API
 
-Bolt uses [WebContainers](https://webcontainers.io/) to run generated code in the browser. WebContainers provide Bolt with a full-stack sandbox environment using [WebContainer API](https://webcontainers.io/api). WebContainers run full-stack applications directly in the browser without the cost and security concerns of cloud hosted AI agents. WebContainers are interactive and editable, and enables Bolt's AI to run code and understand any changes from the user.
+Figplit uses [WebContainers](https://webcontainers.io/) to run generated code in the browser. They give the agent a sandboxed Node.js environment using the [WebContainer API](https://webcontainers.io/api). Because everything compiles in the tab, Figplit can iterate on React, CSS, and animation files instantly—perfect for dialing in hero reveals or motion choreography without waiting on remote servers.
 
-The [WebContainer API](https://webcontainers.io) is free for personal and open source usage. If you're building an application for commercial usage, you can learn more about our [WebContainer API commercial usage pricing here](https://stackblitz.com/pricing#webcontainer-api).
+The [WebContainer API](https://webcontainers.io) is free for personal and open source usage. If you're building an application for commercial usage, review the [WebContainer API commercial usage pricing](https://stackblitz.com/pricing#webcontainer-api).
 
 ### Remix App
 
-Bolt is built with [Remix](https://remix.run/) and
-deployed using [CloudFlare Pages](https://pages.cloudflare.com/) and
-[CloudFlare Workers](https://workers.cloudflare.com/).
+Figplit is built with [Remix](https://remix.run/) and deployed using [Cloudflare Pages](https://pages.cloudflare.com/) plus [Cloudflare Workers](https://workers.cloudflare.com/).
 
 ### AI SDK Integration
 
-Bolt uses the [AI SDK](https://github.com/vercel/ai) to integrate with AI
-models. At this time, Bolt supports using Anthropic's Claude Sonnet 3.5.
-You can get an API key from the [Anthropic API Console](https://console.anthropic.com/) to use with Bolt.
-Take a look at how [Bolt uses the AI SDK](https://github.com/stackblitz/bolt.new/tree/main/app/lib/.server/llm)
+Figplit uses the [AI SDK](https://github.com/vercel/ai) with Anthropic's Claude Sonnet 3.5 model. Grab an API key from the [Anthropic API Console](https://console.anthropic.com/) and inspect the integration in [`app/lib/.server/llm`](./app/lib/.server/llm).
 
 ## Prerequisites
 
@@ -47,7 +41,7 @@ Before you begin, ensure you have the following installed:
 1. Clone the repository (if you haven't already):
 
 ```bash
-git clone https://github.com/stackblitz/bolt.new.git
+git clone https://github.com/YOUR-ORG/Figplit.git
 ```
 
 2. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -1,54 +1,37 @@
-[![Bolt.new: AI-Powered Full-Stack Web Development in the Browser](./public/social_preview_index.jpg)](https://bolt.new)
+[![Figplit — Landing Page AI Studio](./public/social_preview_index.jpg)](https://bolt.new)
 
-# Bolt.new: AI-Powered Full-Stack Web Development in the Browser
+# Figplit: AI Vibe-Coding Agent for Landing Pages
 
-Bolt.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered web dev agent using the Bolt open source codebase, [click here to get started!](./CONTRIBUTING.md)
+Figplit is an opinionated fork of the Bolt.new open-source project that focuses entirely on shipping best-in-class marketing and product landing pages. Instead of trying to build any full-stack application, Figplit leans into the workflows that product teams, founders, and designers use to craft gorgeous public-facing sites with cinematic motion and polished micro-interactions.
 
-## What Makes Bolt.new Different
+Figplit keeps the Bolt foundations—WebContainers, an editable project workspace, and the agentic chat interface—but layers on a design-first experience, curated animation snippets, and prompts that keep the AI centered on storytelling, polish, and brand vibes.
 
-Claude, v0, etc are incredible- but you can't install packages, run backends or edit code. That’s where Bolt.new stands out:
+## Why teams use Figplit
 
-- **Full-Stack in the Browser**: Bolt.new integrates cutting-edge AI models with an in-browser development environment powered by **StackBlitz’s WebContainers**. This allows you to:
-  - Install and run npm tools and libraries (like Vite, Next.js, and more)
-  - Run Node.js servers
-  - Interact with third-party APIs
-  - Deploy to production from chat
-  - Share your work via a URL
+- **Purpose-built for landing pages** – Prompts, examples, and guardrails push the AI toward marketing sites, launch pages, and hero flows instead of generic CRUD apps.
+- **Animation and motion aware** – Figplit understands choreography. It suggests easing curves, orchestrates view transitions, and previews motion so you know how the page feels—not just how it looks.
+- **Reusable visual vocabulary** – A bundled snippet library (see [`/snippets`](./snippets)) gives the agent rich starting points for glassmorphism heroes, marquee reels, pricing matrices, and demo carousels.
+- **Agentic editing loop** – Prompt from the chat panel, watch changes stream into the editor, preview instantly, and deploy without ever leaving the tab.
 
-- **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Bolt.new gives AI models **complete control** over the entire  environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
+## Getting started locally
 
-Whether you’re an experienced developer, a PM or designer, Bolt.new allows you to build production-grade full-stack applications with ease.
+Figplit is built with Remix and Vite, and runs entirely in WebContainers just like Bolt.
 
-For developers interested in building their own AI-powered development tools with WebContainers, check out the open-source Bolt codebase in this repo!
+1. Install dependencies with `pnpm install`.
+2. Provide an Anthropic API key via the `ANTHROPIC_API_KEY` environment variable.
+3. Start the app with `pnpm dev` and open the provided URL.
 
-## Tips and Tricks
+Once running, the left panel hosts the chat agent. The right panel shows code, terminal output, and the live landing page preview.
 
-Here are some tips to get the most out of Bolt.new:
+## Project tour
 
-- **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
+- `app/components/chat` – Chat UI, prompt enhancer, and the design-focused onboarding experience.
+- `app/lib/.server/llm` – Server-side LLM orchestration, including the Figplit-specific system prompt.
+- `snippets/` – High-fidelity React + CSS snippets the agent can remix and adapt for new landing pages.
+- `app/components/workbench` – Editor, preview, and terminal surfaces wired to WebContainers.
 
-- **Use the enhance prompt icon**: Before sending your prompt, try clicking the 'enhance' icon to have the AI model help you refine your prompt, then edit the results before submitting.
+## Roadmap & feedback
 
-- **Scaffold the basics first, then add features**: Make sure the basic structure of your application is in place before diving into more advanced functionality. This helps Bolt understand the foundation of your project and ensure everything is wired up right before building out more advanced functionality.
+This fork starts opinionated but intentionally hackable. We want Figplit to be the fastest way to go from idea to production-ready landing page. If you have ideas, encounter bugs, or want to contribute new snippet packs, open an issue or start a discussion.
 
-- **Batch simple instructions**: Save time by combining simple instructions into one message. For example, you can ask Bolt to change the color scheme, add mobile responsiveness, and restart the dev server, all in one go saving you time and reducing API credit consumption significantly.
-
-## FAQs
-
-**Where do I sign up for a paid plan?**  
-Bolt.new is free to get started. If you need more AI tokens or want private projects, you can purchase a paid subscription in your [Bolt.new](https://bolt.new) settings, in the lower-left hand corner of the application. 
-
-**What happens if I hit the free usage limit?**  
-Once your free daily token limit is reached, AI interactions are paused until the next day or until you upgrade your plan.
-
-**Is Bolt in beta?**  
-Yes, Bolt.new is in beta, and we are actively improving it based on feedback.
-
-**How can I report Bolt.new issues?**  
-Check out the [Issues section](https://github.com/stackblitz/bolt.new/issues) to report an issue or request a new feature. Please use the search feature to check if someone else has already submitted the same issue/request.
-
-**What frameworks/libraries currently work on Bolt?**  
-Bolt.new supports most popular JavaScript frameworks and libraries. If it runs on StackBlitz, it will run on Bolt.new as well.
-
-**How can I add make sure my framework/project works well in bolt?**  
-We are excited to work with the JavaScript ecosystem to improve functionality in Bolt. Reach out to us via [hello@stackblitz.com](mailto:hello@stackblitz.com) to discuss how we can partner!
+Built on the incredible foundations from [Bolt.new](https://bolt.new) and the StackBlitz WebContainer API.

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -4,6 +4,7 @@ import { ClientOnly } from 'remix-utils/client-only';
 import { Menu } from '~/components/sidebar/Menu.client';
 import { IconButton } from '~/components/ui/IconButton';
 import { Workbench } from '~/components/workbench/Workbench.client';
+import { landingSnippetLibrary } from '~/lib/snippets/landing-snippets';
 import { classNames } from '~/utils/classNames';
 import { Messages } from './Messages.client';
 import { SendButton } from './SendButton.client';
@@ -28,12 +29,32 @@ interface BaseChatProps {
 }
 
 const EXAMPLE_PROMPTS = [
-  { text: 'Build a todo app in React using Tailwind' },
-  { text: 'Build a simple blog using Astro' },
-  { text: 'Create a cookie consent form using Material UI' },
-  { text: 'Make a space invaders game' },
-  { text: 'How do I center a div?' },
+  { text: 'Design a hero for an AI analytics SaaS with glassmorphism and orbital animation.' },
+  { text: 'Craft a pricing page for a devtools startup with yearly/monthly toggle and gradient highlights.' },
+  { text: 'Prototype a fintech landing page hero featuring staggered card reveals and subtle parallax.' },
+  { text: 'Refine a launch CTA section with gradient background, badges, and an animated arrow indicator.' },
+  { text: 'Recreate the Intercom-style testimonial marquee with auto-scrolling logos and blur edges.' },
 ];
+
+const FEATURE_CALLOUTS = [
+  {
+    icon: 'i-ph:play-circle-duotone',
+    title: 'Motion-aware prompts',
+    description: 'Explain the choreography and Figplit plans the easing, delay, and scroll triggers for you.',
+  },
+  {
+    icon: 'i-ph:sparkle-duotone',
+    title: 'Tasteful by default',
+    description: 'Color palettes, typography, and spacing start refined so you can focus on story and brand.',
+  },
+  {
+    icon: 'i-ph:stack-duotone',
+    title: 'Snippet recall',
+    description: 'Reuse cinematic hero, pricing, and marquee snippets from the built-in library with one click.',
+  },
+];
+
+const FEATURED_SNIPPETS = landingSnippetLibrary.slice(0, 3);
 
 const TEXTAREA_MIN_HEIGHT = 76;
 
@@ -72,13 +93,62 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
         <div ref={scrollRef} className="flex overflow-y-auto w-full h-full">
           <div className={classNames(styles.Chat, 'flex flex-col flex-grow min-w-[var(--chat-min-width)] h-full')}>
             {!chatStarted && (
-              <div id="intro" className="mt-[26vh] max-w-chat mx-auto">
-                <h1 className="text-5xl text-center font-bold text-bolt-elements-textPrimary mb-2">
-                  Where ideas begin
+              <div id="intro" className="mt-[18vh] max-w-[720px] mx-auto px-6">
+                <h1 className="text-5xl text-center font-bold text-bolt-elements-textPrimary mb-3 leading-tight">
+                  Launch cinematic landing pages in minutes
                 </h1>
-                <p className="mb-4 text-center text-bolt-elements-textSecondary">
-                  Bring ideas to life in seconds or get help on existing projects.
+                <p className="mb-6 text-center text-bolt-elements-textSecondary text-lg">
+                  Pair your vision with Figplit’s taste. Prompt bespoke hero layouts, scroll choreography, and polished
+                  marketing flows without wrangling boilerplate.
                 </p>
+                <div className="mt-8 grid gap-3 text-left md:grid-cols-3">
+                  {FEATURE_CALLOUTS.map((callout) => (
+                    <div
+                      key={callout.title}
+                      className="rounded-2xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-2/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-bolt-elements-background-depth-2/40"
+                    >
+                      <div className="flex items-center gap-2 text-bolt-elements-item-contentAccent text-sm font-semibold">
+                        <div className={`${callout.icon} text-lg`} />
+                        {callout.title}
+                      </div>
+                      <p className="mt-2 text-sm text-bolt-elements-textSecondary leading-relaxed">
+                        {callout.description}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-10 text-left">
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-bolt-elements-textTertiary">
+                    Featured snippet starters
+                  </h2>
+                  <div className="mt-3 grid gap-3 md:grid-cols-3">
+                    {FEATURED_SNIPPETS.map((snippet) => (
+                      <button
+                        key={snippet.id}
+                        type="button"
+                        onClick={(event) => {
+                          sendMessage?.(event, snippet.prompt);
+                        }}
+                        className="group flex flex-col items-start gap-2 rounded-xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/80 p-4 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/20"
+                      >
+                        <div className="flex items-center gap-2 text-sm font-semibold text-bolt-elements-textPrimary">
+                          <div className="i-ph:shapes-duotone text-base text-bolt-elements-item-contentAccent group-hover:text-bolt-elements-item-contentAccent" />
+                          {snippet.title}
+                        </div>
+                        <p className="text-sm text-bolt-elements-textSecondary leading-relaxed">
+                          {snippet.description}
+                        </p>
+                        <div className="text-xs uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
+                          {snippet.bestFor.join(' • ')}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                  <p className="mt-3 text-xs text-bolt-elements-textTertiary">
+                    These live under <code className="font-semibold">/snippets</code>. Ask Figplit to remix them or{' '}
+                    click to seed a prompt with context.
+                  </p>
+                </div>
               </div>
             )}
             <div
@@ -130,7 +200,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       minHeight: TEXTAREA_MIN_HEIGHT,
                       maxHeight: TEXTAREA_MAX_HEIGHT,
                     }}
-                    placeholder="How can Bolt help you today?"
+                    placeholder="What landing page magic should Figplit design next?"
                     translate="no"
                   />
                   <ClientOnly>

--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -18,10 +18,17 @@ export function Header() {
         },
       )}
     >
-      <div className="flex items-center gap-2 z-logo text-bolt-elements-textPrimary cursor-pointer">
-        <div className="i-ph:sidebar-simple-duotone text-xl" />
-        <a href="/" className="text-2xl font-semibold text-accent flex items-center">
-          <span className="i-bolt:logo-text?mask w-[46px] inline-block" />
+      <div className="flex items-center gap-3 z-logo text-bolt-elements-textPrimary">
+        <a href="/" className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-purple-500/80 via-fuchsia-500/80 to-amber-400/80 text-white shadow-sm">
+            <div className="i-ph:sparkle-duotone text-xl" />
+          </div>
+          <div className="flex flex-col leading-tight">
+            <span className="text-2xl font-semibold text-bolt-elements-textPrimary">Figplit</span>
+            <span className="text-xs font-medium uppercase tracking-[0.24em] text-bolt-elements-textSecondary">
+              Landing page studio
+            </span>
+          </div>
         </a>
       </div>
       <span className="flex-1 px-4 truncate text-center text-bolt-elements-textPrimary">

--- a/app/components/header/HeaderActionButtons.client.tsx
+++ b/app/components/header/HeaderActionButtons.client.tsx
@@ -23,7 +23,7 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
             }
           }}
         >
-          <div className="i-bolt:chat text-sm" />
+          <div className="i-ph:chats-teardrop-dots-duotone text-base" />
         </Button>
         <div className="w-[1px] bg-bolt-elements-borderColor" />
         <Button
@@ -36,7 +36,7 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
             workbenchStore.showWorkbench.set(!showWorkbench);
           }}
         >
-          <div className="i-ph:code-bold" />
+          <div className="i-ph:brackets-curly-duotone text-base" />
         </Button>
       </div>
     </div>

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -2,7 +2,6 @@ import { motion, type Variants } from 'framer-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
-import { IconButton } from '~/components/ui/IconButton';
 import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { db, deleteById, getAll, chatId, type ChatHistoryItem } from '~/lib/persistence';
 import { cubicEasingFn } from '~/utils/easings';

--- a/app/lib/.server/llm/prompts.ts
+++ b/app/lib/.server/llm/prompts.ts
@@ -3,7 +3,13 @@ import { allowedHTMLElements } from '~/utils/markdown';
 import { stripIndents } from '~/utils/stripIndent';
 
 export const getSystemPrompt = (cwd: string = WORK_DIR) => `
-You are Bolt, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
+You are Figplit, an elite AI landing page designer/developer with impeccable visual taste, deep knowledge of motion design, and mastery of modern front-end frameworks.
+
+Your entire remit is to craft and refine high-end marketing sites, launch pages, hero flows, and interactive storytelling surfaces. Do not build CRUD dashboards, admin tools, or backend services. Every response should elevate visuals, typography, layout rhythm, accessibility, and purposeful animation.
+
+You have access to a curated snippet library under /snippets. When complex sections or animations are requested, prefer adapting those snippets (e.g., glassmorphism heroes, marquee reels, device rails) rather than reinventing them. Cite which snippet you draw from and tailor it to the current brand.
+
+Always describe how animations should feel when they render, including easing, duration, stagger, and trigger logic, so the user can visualize the result even before previewing.
 
 <system_constraints>
   You are operating in an environment called WebContainer, an in-browser Node.js runtime that emulates a Linux system to some degree. However, it runs in the browser and doesn't run a full-fledged Linux system and doesn't rely on a cloud VM to execute code. All code is executed in the browser. It does come with a shell that emulates zsh. The container cannot run native binaries since those cannot be executed in the browser. That means it can only execute code that is native to a browser including JS, WebAssembly, etc.
@@ -69,7 +75,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
       }
 
       -console.log('Hello, World!');
-      +console.log('Hello, Bolt!');
+      +console.log('Hello, Figplit!');
       +
       function greet() {
       -  return 'Greetings!';
@@ -85,7 +91,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
 </diff_spec>
 
 <artifact_info>
-  Bolt creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
+  Figplit creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
 
   - Shell commands to run including dependencies to install using a package manager (NPM)
   - Files to create and their contents

--- a/app/lib/snippets/landing-snippets.ts
+++ b/app/lib/snippets/landing-snippets.ts
@@ -1,0 +1,41 @@
+export interface LandingSnippet {
+  id: string;
+  title: string;
+  description: string;
+  bestFor: string[];
+  file: string;
+  prompt: string;
+}
+
+export const landingSnippetLibrary: LandingSnippet[] = [
+  {
+    id: 'glass-hero-orbits',
+    title: 'Glassmorphism hero',
+    description:
+      'Frosted hero shell with gradient orbits, layered CTA buttons, and staggered content entrance using framer-motion.',
+    bestFor: ['Hero', 'AI SaaS', 'Product launch'],
+    file: 'snippets/glass-hero-orbits.tsx',
+    prompt:
+      'Use the snippet at /snippets/glass-hero-orbits.tsx as the baseline hero and adapt it to the current brand palette, copy, and CTA structure.',
+  },
+  {
+    id: 'metrics-marquee',
+    title: 'Metrics marquee reel',
+    description:
+      'Infinite auto-scrolling marquee highlighting customer logos and success metrics with gradient edge fades.',
+    bestFor: ['Social proof', 'Testimonials', 'Case studies'],
+    file: 'snippets/metrics-marquee.tsx',
+    prompt:
+      'Blend the marquee loop from /snippets/metrics-marquee.tsx into the page and customize the data + colors to match our product story.',
+  },
+  {
+    id: 'device-rail',
+    title: 'Device showcase rail',
+    description:
+      '3D-tilting device cards with synced autoplay carousel and subtle reflections to showcase in-product screenshots.',
+    bestFor: ['Product demo', 'Feature tour', 'Motion highlight'],
+    file: 'snippets/device-rail.tsx',
+    prompt:
+      'Incorporate the animated rail from /snippets/device-rail.tsx and replace the imagery with our assets while keeping the motion polish.',
+  },
+];

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,7 +5,13 @@ import { Chat } from '~/components/chat/Chat.client';
 import { Header } from '~/components/header/Header';
 
 export const meta: MetaFunction = () => {
-  return [{ title: 'Bolt' }, { name: 'description', content: 'Talk with Bolt, an AI assistant from StackBlitz' }];
+  return [
+    { title: 'Figplit — Landing Page AI Studio' },
+    {
+      name: 'description',
+      content: 'Collaborate with Figplit, the AI vibe coder for world-class landing pages.',
+    },
+  ];
 };
 
 export const loader = () => json({});

--- a/app/routes/api.enhancer.ts
+++ b/app/routes/api.enhancer.ts
@@ -19,7 +19,9 @@ async function enhancerAction({ context, request }: ActionFunctionArgs) {
         {
           role: 'user',
           content: stripIndents`
-          I want you to improve the user prompt that is wrapped in \`<original_prompt>\` tags.
+          I want you to improve the user prompt that is wrapped in \`<original_prompt>\` tags with the goal of crafting a world-class landing page experience.
+
+          Encourage the user to specify brand vibe, target audience, desired layout sections, motion/animation intentions, asset needs, and any snippets from /snippets that could accelerate the build.
 
           IMPORTANT: Only respond with the improved prompt and nothing else!
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,3 +1,3 @@
 export const WORK_DIR_NAME = 'project';
 export const WORK_DIR = `/home/${WORK_DIR_NAME}`;
-export const MODIFICATIONS_TAG_NAME = 'bolt_file_modifications';
+export const MODIFICATIONS_TAG_NAME = 'figplit_file_modifications';

--- a/app/utils/diff.ts
+++ b/app/utils/diff.ts
@@ -81,12 +81,12 @@ export function diffFiles(fileName: string, oldFileContent: string, newFileConte
  * Example:
  *
  * ```html
- * <bolt_file_modifications>
+ * <figplit_file_modifications>
  * <diff path="/home/project/index.js">
  * - console.log('Hello, World!');
- * + console.log('Hello, Bolt!');
+ * + console.log('Hello, Figplit!');
  * </diff>
- * </bolt_file_modifications>
+ * </figplit_file_modifications>
  * ```
  */
 export function fileModificationsToHTML(modifications: FileModifications) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bolt",
-  "description": "StackBlitz AI Agent",
+  "name": "figplit",
+  "description": "AI vibe-coding agent for landing pages",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@9.4.0",

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -1,0 +1,11 @@
+# Figplit snippet library
+
+These snippets are high-fidelity building blocks the Figplit agent can reference when composing new landing pages. Each file is written in TypeScript + React and leans on Tailwind/Uno utility classes and framer-motion for motion choreography. The agent can copy, remix, or adapt them directly.
+
+## Available snippets
+
+- `glass-hero-orbits.tsx` – Glassmorphism hero with gradient orbits, two CTA buttons, and layered blur accents.
+- `metrics-marquee.tsx` – Auto-scrolling marquee for logos and success metrics with gradient edge fades.
+- `device-rail.tsx` – Responsive showcase rail with animated device cards and synchronized autoplay.
+
+Add more snippets here to expand the agent’s vocabulary. Reference paths from prompts using `/snippets/<file-name>.tsx`.

--- a/snippets/device-rail.tsx
+++ b/snippets/device-rail.tsx
@@ -1,0 +1,67 @@
+import { motion } from 'framer-motion';
+
+interface DeviceRailProps {
+  heading: string;
+  description: string;
+  screenshots: Array<{ src: string; alt: string; label: string }>;
+}
+
+/**
+ * Animated device rail with subtle 3D tilt and autoplay reveal.
+ * Pair with gradients behind the section for extra depth.
+ */
+export function DeviceRail({ heading, description, screenshots }: DeviceRailProps) {
+  return (
+    <section className="relative overflow-hidden bg-slate-950 py-20 text-white">
+      <div className="absolute inset-0 opacity-40">
+        <div className="absolute inset-x-0 top-1/3 h-64 bg-gradient-to-r from-purple-500/40 via-sky-500/20 to-teal-400/30 blur-[140px]" />
+      </div>
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <div className="max-w-3xl space-y-4 text-center md:text-left">
+          <h2 className="text-4xl font-semibold leading-tight text-balance">{heading}</h2>
+          <p className="text-lg text-white/70">{description}</p>
+        </div>
+
+        <div className="relative flex flex-col gap-16">
+          <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+          <div className="grid gap-8 md:grid-cols-3">
+            {screenshots.map((shot, index) => (
+              <motion.article
+                key={shot.src}
+                className="group relative rounded-[2rem] border border-white/10 bg-white/5 p-6 backdrop-blur"
+                initial={{ opacity: 0, y: 32 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 + index * 0.1, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+                whileHover={{ rotateX: -4, rotateY: 6, scale: 1.02 }}
+              >
+                <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-gradient-to-br from-white/10 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                <div className="relative overflow-hidden rounded-3xl border border-white/10 shadow-2xl shadow-slate-950/60">
+                  <motion.img
+                    src={shot.src}
+                    alt={shot.alt}
+                    className="h-full w-full object-cover"
+                    initial={{ scale: 1.05 }}
+                    animate={{ scale: 1 }}
+                    transition={{ delay: 0.4 + index * 0.12, duration: 0.8, ease: [0.33, 1, 0.68, 1] }}
+                  />
+                </div>
+                <div className="mt-5 flex items-center justify-between text-sm text-white/70">
+                  <span className="font-medium text-white/90">{shot.label}</span>
+                  <motion.span
+                    className="inline-flex items-center gap-1 text-xs uppercase tracking-[0.28em]"
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.5 + index * 0.12, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+                  >
+                    <span className="i-ph:waveform-duotone text-sm" />
+                    Live demo
+                  </motion.span>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/snippets/glass-hero-orbits.tsx
+++ b/snippets/glass-hero-orbits.tsx
@@ -1,0 +1,98 @@
+import { motion } from 'framer-motion';
+
+type GlassHeroProps = {
+  eyebrow?: string;
+  heading: string;
+  copy: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta?: { label: string; href: string };
+};
+
+/**
+ * Frosted-glass hero with orbital gradient accents and staggered content entrance.
+ * Works great for AI, analytics, or productivity tools that want a cinematic opening.
+ */
+export function GlassHeroOrbits({
+  eyebrow = 'Featured launch',
+  heading,
+  copy,
+  primaryCta,
+  secondaryCta,
+}: GlassHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-slate-950 py-24 text-white">
+      <div className="absolute inset-0">
+        <div className="absolute -top-40 right-10 h-72 w-72 rounded-full bg-gradient-to-br from-fuchsia-500/40 via-purple-400/20 to-sky-400/30 blur-3xl" />
+        <div className="absolute bottom-[-200px] left-1/4 h-[420px] w-[420px] rounded-full bg-gradient-to-tl from-emerald-500/40 via-cyan-400/20 to-transparent blur-[120px]" />
+        <motion.div
+          aria-hidden
+          className="absolute inset-0"
+          initial={{ rotate: 0 }}
+          animate={{ rotate: 360 }}
+          transition={{ duration: 18, repeat: Infinity, ease: 'linear' }}
+        >
+          <div className="absolute left-[45%] top-16 h-12 w-12 rounded-full border border-white/30 bg-white/10 blur-[1px]" />
+          <div className="absolute bottom-28 right-[20%] h-16 w-16 rounded-full border border-white/40 bg-white/5" />
+        </motion.div>
+      </div>
+
+      <div className="relative mx-auto flex max-w-5xl flex-col items-center gap-8 px-6 text-center">
+        <motion.span
+          className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em]"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <span className="i-ph:sparkle-duotone text-sm" />
+          {eyebrow}
+        </motion.span>
+        <motion.h1
+          className="text-balance text-5xl font-bold sm:text-6xl"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+        >
+          {heading}
+        </motion.h1>
+        <motion.p
+          className="max-w-2xl text-lg text-white/70"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.35, duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+        >
+          {copy}
+        </motion.p>
+        <motion.div
+          className="flex flex-wrap items-center justify-center gap-4"
+          initial="hidden"
+          animate="visible"
+          variants={{
+            hidden: {},
+            visible: { transition: { staggerChildren: 0.08, delayChildren: 0.45 } },
+          }}
+        >
+          <motion.a
+            variants={{ hidden: { opacity: 0, y: 16 }, visible: { opacity: 1, y: 0 } }}
+            whileHover={{ scale: 1.015 }}
+            whileTap={{ scale: 0.98 }}
+            href={primaryCta.href}
+            className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-fuchsia-500/25"
+          >
+            {primaryCta.label}
+          </motion.a>
+          {secondaryCta ? (
+            <motion.a
+              variants={{ hidden: { opacity: 0, y: 16 }, visible: { opacity: 1, y: 0 } }}
+              whileHover={{ scale: 1.01 }}
+              whileTap={{ scale: 0.99 }}
+              href={secondaryCta.href}
+              className="rounded-full border border-white/30 bg-white/5 px-6 py-3 text-sm font-semibold text-white/90 backdrop-blur"
+            >
+              {secondaryCta.label}
+            </motion.a>
+          ) : null}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/snippets/metrics-marquee.tsx
+++ b/snippets/metrics-marquee.tsx
@@ -1,0 +1,68 @@
+import { motion } from 'framer-motion';
+
+interface Metric {
+  label: string;
+  value: string;
+}
+
+interface LogoMarqueeProps {
+  heading?: string;
+  metrics: Metric[];
+  logos: string[];
+}
+
+/**
+ * Auto-scrolling marquee mixing customer logos with key metrics.
+ * Edge gradients fade the loop to avoid harsh seams.
+ */
+export function MetricsMarquee({ heading = 'Loved by teams shipping fast', metrics, logos }: LogoMarqueeProps) {
+  const loop = [...logos, ...logos];
+
+  return (
+    <section className="relative overflow-hidden bg-slate-950 py-16 text-white">
+      <div
+        className="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-slate-950 via-slate-950/70 to-transparent"
+        aria-hidden
+      />
+      <div
+        className="absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-slate-950 via-slate-950/70 to-transparent"
+        aria-hidden
+      />
+
+      <div className="relative mx-auto flex max-w-5xl flex-col gap-8 px-6">
+        <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-2xl font-semibold text-white/90 sm:text-3xl">{heading}</h2>
+          <div className="flex flex-wrap gap-4 text-sm text-white/70">
+            {metrics.map((metric) => (
+              <div key={metric.label} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 backdrop-blur">
+                <div className="text-xs uppercase tracking-[0.28em] text-white/50">{metric.label}</div>
+                <div className="text-lg font-semibold text-white">{metric.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {[0, 1].map((row) => (
+            <motion.div
+              key={row}
+              className="flex min-w-full gap-10"
+              initial={{ x: row % 2 === 0 ? 0 : -200 }}
+              animate={{ x: row % 2 === 0 ? -600 : 0 }}
+              transition={{ duration: 18, repeat: Infinity, ease: 'linear' }}
+            >
+              {loop.map((logo, index) => (
+                <div key={`${row}-${index}`} className="flex items-center gap-3 opacity-70 hover:opacity-100">
+                  <div className="h-10 w-10 rounded-full bg-white/10 backdrop-blur flex items-center justify-center">
+                    <span className="text-sm font-semibold uppercase tracking-wide">{logo.charAt(0)}</span>
+                  </div>
+                  <span className="text-sm font-medium text-white/80">{logo}</span>
+                </div>
+              ))}
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- rebrand the home experience and header around Figplit as a landing-page-first agent
- introduce a curated snippet library and onboarding cards that seed prompts for premium motion patterns
- tune the system prompt and enhancer workflow to enforce landing-page scope and reuse of the new snippets

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce63a093c08328be38ea13f3b94391