### PR TITLE
Support snippet retrieval in chat flow

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -55,6 +55,7 @@ const FEATURE_CALLOUTS = [
 ];
 
 const FEATURED_SNIPPETS = landingSnippetLibrary.slice(0, 3);
+const SNIPPET_RECOMMENDATIONS = landingSnippetLibrary;
 
 const TEXTAREA_MIN_HEIGHT = 76;
 
@@ -168,6 +169,34 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   ) : null;
                 }}
               </ClientOnly>
+              {chatStarted ? (
+                <div className="mx-auto mt-4 w-full max-w-chat px-4">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.28em] text-bolt-elements-textTertiary">
+                    Snippet recommendations
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {SNIPPET_RECOMMENDATIONS.map((snippet) => (
+                      <button
+                        key={`recommendation-${snippet.id}`}
+                        type="button"
+                        onClick={(event) => {
+                          sendMessage?.(event, snippet.prompt);
+                        }}
+                        className="group flex min-w-[180px] flex-col items-start gap-1 rounded-lg border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/60 px-3 py-2 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10"
+                      >
+                        <span className="text-sm font-semibold text-bolt-elements-textPrimary group-hover:text-bolt-elements-item-contentAccent">
+                          {snippet.title}
+                        </span>
+                        {snippet.bestFor?.length ? (
+                          <span className="text-[11px] uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
+                            {snippet.bestFor.join(' • ')}
+                          </span>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
               <div
                 className={classNames('relative w-full max-w-chat mx-auto z-prompt', {
                   'sticky bottom-0': chatStarted,

--- a/app/lib/.server/snippets/registry.test.ts
+++ b/app/lib/.server/snippets/registry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findSnippetsInText,
+  getSnippetByPath,
+  getSnippets,
+} from '~/lib/.server/snippets/registry';
+
+describe('snippet registry', () => {
+  it('exposes snippet metadata and code from the snippets directory', () => {
+    const allSnippets = getSnippets();
+    const glassSnippet = getSnippetByPath('/snippets/glass-hero-orbits.tsx');
+
+    expect(allSnippets.length).toBeGreaterThan(0);
+    expect(glassSnippet).toBeDefined();
+    expect(glassSnippet?.title).toBe('Glassmorphism hero');
+    expect(glassSnippet?.description).toContain('Frosted hero shell');
+    expect(glassSnippet?.code).toContain('export function GlassHeroOrbits');
+  });
+
+  it('finds snippet mentions within arbitrary text', () => {
+    const snippets = findSnippetsInText(
+      'Blend snippets/glass-hero-orbits.tsx with /snippets/metrics-marquee.tsx and ignore repeats like /snippets/metrics-marquee.tsx.',
+    );
+
+    expect(snippets.map((snippet) => snippet.id)).toEqual([
+      'glass-hero-orbits',
+      'metrics-marquee',
+    ]);
+  });
+});

--- a/app/lib/.server/snippets/registry.ts
+++ b/app/lib/.server/snippets/registry.ts
@@ -1,0 +1,198 @@
+import { landingSnippetLibrary } from '~/lib/snippets/landing-snippets';
+
+export interface SnippetMetadata {
+  id: string;
+  title: string;
+  description?: string;
+  path: string;
+  filename: string;
+  bestFor?: string[];
+  prompt?: string;
+  docblock: string[];
+}
+
+export interface SnippetRecord extends SnippetMetadata {
+  code: string;
+}
+
+interface Registry {
+  entries: SnippetRecord[];
+  byPath: Map<string, SnippetRecord>;
+  byId: Map<string, SnippetRecord>;
+}
+
+const SNIPPET_SOURCES = import.meta.glob('../../../../snippets/**/*.{ts,tsx}', {
+  as: 'raw',
+  eager: true,
+});
+
+const SNIPPET_LIBRARY_BY_PATH = new Map(
+  landingSnippetLibrary
+    .map((snippet) => {
+      const normalized = normalizeSnippetPath(snippet.file);
+
+      if (!normalized) {
+        return null;
+      }
+
+      return [normalized.toLowerCase(), snippet] as const;
+    })
+    .filter((entry): entry is readonly [string, (typeof landingSnippetLibrary)[number]] => entry !== null),
+);
+
+const SNIPPET_REGISTRY: Registry = buildRegistry();
+
+const SNIPPET_MENTION_PATTERN = /(?:\/)?snippets\/[A-Za-z0-9/_-]+\.(?:t|j)sx?/gi;
+
+function buildRegistry(): Registry {
+  const entries: SnippetRecord[] = [];
+  const byPath = new Map<string, SnippetRecord>();
+  const byId = new Map<string, SnippetRecord>();
+
+  for (const [modulePath, code] of Object.entries(SNIPPET_SOURCES)) {
+    const relativeMatch = modulePath.match(/\/snippets\/(.+)$/);
+
+    if (!relativeMatch) {
+      continue;
+    }
+
+    const filename = relativeMatch[1];
+    const normalizedPath = `/snippets/${filename}`;
+    const id = filename.replace(/\.(?:t|j)sx?$/i, '');
+    const docblock = extractDocblockLines(code);
+
+    const libraryMeta = SNIPPET_LIBRARY_BY_PATH.get(normalizedPath.toLowerCase());
+
+    const record: SnippetRecord = {
+      id,
+      filename,
+      path: normalizedPath,
+      title: libraryMeta?.title ?? toTitleCase(id),
+      description: libraryMeta?.description ?? docblock[0],
+      bestFor: libraryMeta?.bestFor,
+      prompt: libraryMeta?.prompt,
+      docblock,
+      code,
+    };
+
+    entries.push(record);
+    byPath.set(normalizedPath.toLowerCase(), record);
+    byId.set(id.toLowerCase(), record);
+  }
+
+  entries.sort((a, b) => a.title.localeCompare(b.title));
+
+  return {
+    entries,
+    byPath,
+    byId,
+  };
+}
+
+function extractDocblockLines(source: string): string[] {
+  const match = source.match(/\/\*\*([\s\S]*?)\*\//);
+
+  if (!match) {
+    return [];
+  }
+
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim().replace(/^\*\s?/, '').trim())
+    .filter((line) => line.length > 0);
+}
+
+function toTitleCase(slug: string): string {
+  return slug
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function normalizeSnippetPath(rawPath: string): string | null {
+  let candidate = rawPath.trim();
+
+  candidate = candidate.replace(/^[`'"({\[]+/, '');
+  candidate = candidate.replace(/[`'"})\].,:;!?]+$/, '');
+  candidate = candidate.replace(/\\/g, '/');
+
+  if (candidate.startsWith('snippets/')) {
+    candidate = `/${candidate}`;
+  }
+
+  if (!candidate.toLowerCase().startsWith('/snippets/')) {
+    return null;
+  }
+
+  return candidate;
+}
+
+export function getSnippets(): SnippetRecord[] {
+  return SNIPPET_REGISTRY.entries.slice();
+}
+
+export function getSnippetByPath(path: string): SnippetRecord | undefined {
+  const normalized = normalizeSnippetPath(path);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return SNIPPET_REGISTRY.byPath.get(normalized.toLowerCase());
+}
+
+export function getSnippetById(id: string): SnippetRecord | undefined {
+  return SNIPPET_REGISTRY.byId.get(id.trim().toLowerCase());
+}
+
+export function findSnippetsInText(text: string): SnippetRecord[] {
+  const matches = text.matchAll(SNIPPET_MENTION_PATTERN);
+  const results: SnippetRecord[] = [];
+  const seen = new Set<string>();
+
+  for (const match of matches) {
+    const normalized = normalizeSnippetPath(match[0]);
+
+    if (!normalized) {
+      continue;
+    }
+
+    const key = normalized.toLowerCase();
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    const record = SNIPPET_REGISTRY.byPath.get(key);
+
+    if (record) {
+      seen.add(key);
+      results.push(record);
+    }
+  }
+
+  return results;
+}
+
+export function findSnippetsInMessages(messages: Array<{ content: string }>): SnippetRecord[] {
+  const seen = new Set<string>();
+  const results: SnippetRecord[] = [];
+
+  for (const message of messages) {
+    const snippets = findSnippetsInText(message.content);
+
+    for (const snippet of snippets) {
+      const key = snippet.path.toLowerCase();
+
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      results.push(snippet);
+    }
+  }
+
+  return results;
+}

--- a/app/routes/api.chat.test.ts
+++ b/app/routes/api.chat.test.ts
@@ -1,0 +1,59 @@
+import type { ActionFunctionArgs } from '@remix-run/cloudflare';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { chatAction } from '~/routes/api.chat';
+
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock('~/lib/.server/llm/stream-text', () => ({
+  streamText: streamTextMock,
+}));
+
+beforeEach(() => {
+  streamTextMock.mockReset();
+  streamTextMock.mockResolvedValue({
+    toAIStream: () =>
+      new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+  });
+});
+
+describe('chatAction', () => {
+  it('augments the final user message with snippet context when mentions are present', async () => {
+    const request = new Request('http://localhost/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages: [
+          { role: 'assistant', content: 'Hello! How can I help today?' },
+          {
+            role: 'user',
+            content: 'Remix the hero using /snippets/glass-hero-orbits.tsx and refine animations.',
+          },
+        ],
+      }),
+    });
+
+    const context = { cloudflare: { env: {} } };
+
+    const response = await chatAction({
+      context,
+      request,
+      params: {},
+    } as unknown as ActionFunctionArgs);
+
+    expect(response).toBeInstanceOf(Response);
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+
+    const [messages] = streamTextMock.mock.calls[0];
+    const lastMessage = messages[messages.length - 1];
+
+    expect(lastMessage.content).toContain('Remix the hero using /snippets/glass-hero-orbits.tsx');
+    expect(lastMessage.content).toContain('Relevant snippet context:');
+    expect(lastMessage.content).toContain('export function GlassHeroOrbits');
+  });
+});


### PR DESCRIPTION
## Summary
- add a server-side snippet registry that materializes metadata and source from the /snippets directory for reuse
- augment the chat action to detect snippet mentions, append the resolved context, and expose snippet recommendations in the chat UI
- cover the registry and chat augmentation paths with new Vitest suites

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6815a4288328a559145a506af713