### PR TITLE
Add ability to abort running workbench actions

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -18,6 +18,7 @@ interface BaseChatProps {
   showChat?: boolean;
   chatStarted?: boolean;
   isStreaming?: boolean;
+  aborted?: boolean;
   messages?: Message[];
   enhancingPrompt?: boolean;
   promptEnhanced?: boolean;
@@ -67,6 +68,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       showChat = true,
       chatStarted = false,
       isStreaming = false,
+      aborted = false,
       enhancingPrompt = false,
       promptEnhanced = false,
       messages,
@@ -164,6 +166,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       className="flex flex-col w-full flex-1 max-w-chat px-4 pb-6 mx-auto z-1"
                       messages={messages}
                       isStreaming={isStreaming}
+                      aborted={aborted}
                     />
                   ) : null;
                 }}

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -71,7 +71,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
 
   const [chatStarted, setChatStarted] = useState(initialMessages.length > 0);
 
-  const { showChat } = useStore(chatStore);
+  const { showChat, aborted } = useStore(chatStore);
 
   const [animationScope, animate] = useAnimate();
 
@@ -205,6 +205,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
       input={input}
       showChat={showChat}
       chatStarted={chatStarted}
+      aborted={aborted}
       isStreaming={isLoading}
       enhancingPrompt={enhancingPrompt}
       promptEnhanced={promptEnhanced}

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -8,11 +8,12 @@ interface MessagesProps {
   id?: string;
   className?: string;
   isStreaming?: boolean;
+  aborted?: boolean;
   messages?: Message[];
 }
 
 export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: MessagesProps, ref) => {
-  const { id, isStreaming = false, messages = [] } = props;
+  const { id, isStreaming = false, aborted = false, messages = [] } = props;
 
   return (
     <div id={id} ref={ref} className={props.className}>
@@ -47,6 +48,12 @@ export const Messages = React.forwardRef<HTMLDivElement, MessagesProps>((props: 
         : null}
       {isStreaming && (
         <div className="text-center w-full text-bolt-elements-textSecondary i-svg-spinners:3-dots-fade text-4xl mt-4"></div>
+      )}
+      {!isStreaming && aborted && (
+        <div className="flex items-center justify-center gap-2 text-bolt-elements-textSecondary text-sm mt-4">
+          <div className="i-ph:hand-palm"></div>
+          Generation stopped.
+        </div>
       )}
     </div>
   );

--- a/app/lib/runtime/action-runner.spec.ts
+++ b/app/lib/runtime/action-runner.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ActionRunner } from './action-runner';
+import type { ActionCallbackData } from './message-parser';
+
+describe('ActionRunner', () => {
+  const createShellAction = (actionId: string, content = 'echo "hello"'): ActionCallbackData => ({
+    artifactId: 'artifact-1',
+    messageId: 'message-1',
+    actionId,
+    action: {
+      type: 'shell',
+      content,
+    },
+  });
+
+  it('abortAll aborts running and pending actions', async () => {
+    let resolveExit!: (value: number) => void;
+    const exitPromise = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+
+    const kill = vi.fn();
+    const pipeTo = vi.fn(() => Promise.resolve());
+
+    const spawn = vi.fn(async () => ({
+      kill,
+      exit: exitPromise,
+      output: { pipeTo },
+    }));
+
+    const runner = new ActionRunner(Promise.resolve({ spawn } as any));
+
+    const runningAction = createShellAction('action-1');
+    const pendingAction = createShellAction('action-2', 'echo "pending"');
+
+    runner.addAction(runningAction);
+    runner.runAction(runningAction);
+    runner.addAction(pendingAction);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(runner.actions.get()[runningAction.actionId].status).toBe('running');
+    expect(runner.actions.get()[pendingAction.actionId].status).toBe('pending');
+
+    runner.abortAll();
+
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(runner.actions.get()[runningAction.actionId].status).toBe('aborted');
+    expect(runner.actions.get()[pendingAction.actionId].status).toBe('aborted');
+
+    resolveExit(0);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runner.actions.get()[runningAction.actionId].status).toBe('aborted');
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -95,6 +95,17 @@ export class ActionRunner {
       });
   }
 
+  abortAll() {
+    const actions = this.actions.get();
+
+    for (const [actionId, action] of Object.entries(actions)) {
+      if (action.status === 'pending' || action.status === 'running') {
+        logger.debug('Aborting action', actionId);
+        action.abort();
+      }
+    }
+  }
+
   async #executeAction(actionId: string) {
     const action = this.actions.get()[actionId];
 

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -211,7 +211,11 @@ export class WorkbenchStore {
   }
 
   abortAllActions() {
-    // TODO: what do we wanna do and how do we wanna recover from this?
+    const artifacts = this.artifacts.get();
+
+    for (const artifact of Object.values(artifacts)) {
+      artifact.runner.abortAll();
+    }
   }
 
   addArtifact({ messageId, title, id }: ArtifactCallbackData) {


### PR DESCRIPTION
## Summary
- add an `abortAll` helper on `ActionRunner` and wire `WorkbenchStore.abortAllActions` to cancel outstanding artifact tasks
- surface aborted runs in the chat UI so users see when execution stops
- cover the runner abort flow with a vitest spec to ensure commands are killed and statuses update

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce684a138883288397cde2dfcebd58