### PR TITLE
Add deployment preview workflow to workbench

### DIFF
--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -2,8 +2,9 @@ import { useStore } from '@nanostores/react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { chatStore } from '~/lib/stores/chat';
 import { classNames } from '~/utils/classNames';
-import { HeaderActionButtons } from './HeaderActionButtons.client';
 import { ChatDescription } from '~/lib/persistence/ChatDescription.client';
+import { DeployDialog } from '~/components/workbench/DeployDialog.client';
+import { HeaderActionButtons } from './HeaderActionButtons.client';
 
 export function Header() {
   const chat = useStore(chatStore);
@@ -37,9 +38,12 @@ export function Header() {
       {chat.started && (
         <ClientOnly>
           {() => (
-            <div className="mr-1">
-              <HeaderActionButtons />
-            </div>
+            <>
+              <div className="mr-1">
+                <HeaderActionButtons />
+              </div>
+              <DeployDialog />
+            </>
           )}
         </ClientOnly>
       )}

--- a/app/components/header/HeaderActionButtons.client.tsx
+++ b/app/components/header/HeaderActionButtons.client.tsx
@@ -38,6 +38,14 @@ export function HeaderActionButtons({}: HeaderActionButtonsProps) {
         >
           <div className="i-ph:brackets-curly-duotone text-base" />
         </Button>
+        <div className="w-[1px] bg-bolt-elements-borderColor" />
+        <Button
+          onClick={() => {
+            workbenchStore.setDeployDialogOpen(true);
+          }}
+        >
+          <div className="i-ph:rocket-launch-duotone text-base" />
+        </Button>
       </div>
     </div>
   );

--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -43,14 +43,15 @@ export const dialogVariants = {
 interface DialogButtonProps {
   type: 'primary' | 'secondary' | 'danger';
   children: ReactNode;
+  disabled?: boolean;
   onClick?: (event: React.UIEvent) => void;
 }
 
-export const DialogButton = memo(({ type, children, onClick }: DialogButtonProps) => {
+export const DialogButton = memo(({ type, children, disabled = false, onClick }: DialogButtonProps) => {
   return (
     <button
       className={classNames(
-        'inline-flex h-[35px] items-center justify-center rounded-lg px-4 text-sm leading-none focus:outline-none',
+        'inline-flex h-[35px] items-center justify-center rounded-lg px-4 text-sm leading-none focus:outline-none transition-colors duration-150',
         {
           'bg-bolt-elements-button-primary-background text-bolt-elements-button-primary-text hover:bg-bolt-elements-button-primary-backgroundHover':
             type === 'primary',
@@ -59,7 +60,11 @@ export const DialogButton = memo(({ type, children, onClick }: DialogButtonProps
           'bg-bolt-elements-button-danger-background text-bolt-elements-button-danger-text hover:bg-bolt-elements-button-danger-backgroundHover':
             type === 'danger',
         },
+        {
+          'cursor-not-allowed opacity-50 pointer-events-none': disabled,
+        },
       )}
+      disabled={disabled}
       onClick={onClick}
     >
       {children}

--- a/app/components/workbench/DeployDialog.client.tsx
+++ b/app/components/workbench/DeployDialog.client.tsx
@@ -1,0 +1,87 @@
+import { useStore } from '@nanostores/react';
+import { useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogButton, DialogDescription, DialogRoot, DialogTitle } from '~/components/ui/Dialog';
+import { workbenchStore } from '~/lib/stores/workbench';
+
+export function DeployDialog() {
+  const open = useStore(workbenchStore.deployDialogOpen);
+  const deployment = useStore(workbenchStore.deploymentState);
+  const unsavedFiles = useStore(workbenchStore.unsavedFiles);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setIsSubmitting(false);
+      setLocalError(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (deployment.status !== 'error') {
+      setLocalError(null);
+    }
+  }, [deployment.status]);
+
+  const deploymentError = useMemo(() => {
+    if (deployment.status !== 'error') {
+      return null;
+    }
+
+    return deployment.error ?? 'Deployment failed. Please try again.';
+  }, [deployment.error, deployment.status]);
+
+  const handleClose = () => {
+    workbenchStore.setDeployDialogOpen(false);
+  };
+
+  const handleDeploy = async () => {
+    setIsSubmitting(true);
+    setLocalError(null);
+
+    try {
+      await workbenchStore.requestDeployment();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to start deployment';
+      setLocalError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const unsavedFilesCount = useMemo(() => unsavedFiles.size, [unsavedFiles]);
+
+  return (
+    <DialogRoot open={open}>
+      <Dialog onBackdrop={handleClose} onClose={handleClose}>
+        <DialogTitle>Deploy Preview</DialogTitle>
+        <DialogDescription>
+          <div className="space-y-3 text-sm leading-relaxed">
+            <p>
+              Trigger a temporary deployment to generate a live preview URL. Figplit will build the current project
+              using your saved files.
+            </p>
+            {unsavedFilesCount > 0 && (
+              <p className="text-amber-500">
+                You have {unsavedFilesCount} unsaved {unsavedFilesCount === 1 ? 'file' : 'files'}. Save them before
+                deploying to ensure the preview is up to date.
+              </p>
+            )}
+            {(localError || deploymentError) && <p className="text-rose-500">{localError ?? deploymentError}</p>}
+          </div>
+        </DialogDescription>
+        <div className="flex justify-end gap-2 px-5 pb-5 pt-2">
+          <DialogButton type="secondary" onClick={handleClose} disabled={isSubmitting}>
+            Cancel
+          </DialogButton>
+          <DialogButton type="primary" onClick={handleDeploy} disabled={isSubmitting}>
+            <span className="inline-flex items-center gap-2">
+              {isSubmitting && <span className="i-svg-spinners:90-ring-with-bg text-base" />}
+              <span>{isSubmitting ? 'Starting deployment…' : 'Deploy'}</span>
+            </span>
+          </DialogButton>
+        </div>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/components/workbench/DeploymentStatusBanner.client.tsx
+++ b/app/components/workbench/DeploymentStatusBanner.client.tsx
@@ -1,0 +1,80 @@
+import { useStore } from '@nanostores/react';
+import { useEffect } from 'react';
+import { IconButton } from '~/components/ui/IconButton';
+import { workbenchStore } from '~/lib/stores/workbench';
+import { classNames } from '~/utils/classNames';
+
+const statusMessages = {
+  triggering: 'Starting deployment…',
+  queued: 'Deployment queued. Waiting for the build to begin…',
+  building: 'Deployment in progress. Hang tight while we generate your preview…',
+  success: 'Preview deployed successfully.',
+  error: 'Deployment failed.',
+} as const;
+
+const statusIcons = {
+  triggering: 'i-svg-spinners:90-ring-with-bg',
+  queued: 'i-svg-spinners:90-ring-with-bg',
+  building: 'i-svg-spinners:90-ring-with-bg',
+  success: 'i-ph:check-circle-duotone',
+  error: 'i-ph:warning-octagon-duotone',
+} as const;
+
+const accentClasses = {
+  triggering: 'text-bolt-elements-textSecondary',
+  queued: 'text-bolt-elements-textSecondary',
+  building: 'text-bolt-elements-textSecondary',
+  success: 'text-emerald-400',
+  error: 'text-rose-500',
+} as const;
+
+export function DeploymentStatusBanner() {
+  const deployment = useStore(workbenchStore.deploymentState);
+
+  useEffect(() => {
+    workbenchStore.resumeDeploymentPolling();
+  }, []);
+
+  if (deployment.status === 'idle') {
+    return null;
+  }
+
+  const status = deployment.status === 'triggering' ? 'triggering' : deployment.status;
+  const message = statusMessages[status];
+  const icon = statusIcons[status];
+  const accent = accentClasses[status];
+
+  return (
+    <div
+      className={classNames(
+        'ml-3 flex items-center gap-2 rounded-md border border-bolt-elements-borderColor bg-bolt-elements-background-depth-3 px-3 py-1.5 text-sm text-bolt-elements-textSecondary shadow-sm',
+        {
+          'border-emerald-500/40 text-emerald-200': status === 'success',
+          'border-rose-500/40 text-rose-200': status === 'error',
+        },
+      )}
+    >
+      <div className={classNames('text-base', accent, icon)} />
+      <span className="flex-1">
+        {status === 'error' && deployment.error ? `${message} ${deployment.error}` : message}
+      </span>
+      {deployment.previewUrl && status === 'success' && (
+        <a
+          href={deployment.previewUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-bolt-elements-item-contentAccent underline-offset-4 hover:underline"
+        >
+          Open preview
+        </a>
+      )}
+      <IconButton
+        icon="i-ph:x"
+        size="md"
+        onClick={() => {
+          workbenchStore.dismissDeployment();
+        }}
+      />
+    </div>
+  );
+}

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -14,6 +14,7 @@ import { workbenchStore, type WorkbenchViewType } from '~/lib/stores/workbench';
 import { classNames } from '~/utils/classNames';
 import { cubicEasingFn } from '~/utils/easings';
 import { renderLogger } from '~/utils/logger';
+import { DeploymentStatusBanner } from '~/components/workbench/DeploymentStatusBanner.client';
 import { EditorPanel } from './EditorPanel';
 import { Preview } from './Preview';
 
@@ -120,6 +121,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
             <div className="h-full flex flex-col bg-bolt-elements-background-depth-2 border border-bolt-elements-borderColor shadow-sm rounded-lg overflow-hidden">
               <div className="flex items-center px-3 py-2 border-b border-bolt-elements-borderColor">
                 <Slider selected={selectedView} options={sliderOptions} setSelected={setSelectedView} />
+                <DeploymentStatusBanner />
                 <div className="ml-auto" />
                 {selectedView === 'code' && (
                   <PanelHeaderButton

--- a/app/lib/stores/__tests__/workbench.deploy.test.ts
+++ b/app/lib/stores/__tests__/workbench.deploy.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/lib/webcontainer', () => {
+  const mockWebcontainer = {
+    workdir: '/tmp/workdir',
+    fs: { writeFile: vi.fn() },
+    internal: { watchPaths: vi.fn() },
+    on: vi.fn(),
+  };
+
+  return {
+    webcontainer: Promise.resolve(mockWebcontainer),
+    webcontainerContext: { loaded: true },
+  };
+});
+
+import { WorkbenchStore } from '~/lib/stores/workbench';
+
+describe('WorkbenchStore deployment flow', () => {
+  let store: WorkbenchStore;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    store = new WorkbenchStore();
+  });
+
+  afterEach(() => {
+    store.cancelDeploymentPolling();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('updates deployment state to success after requestDeployment', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ status: 'success', previewUrl: 'https://preview.example', deploymentId: 'abc123' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    store.setDeployDialogOpen(true);
+
+    const state = await store.requestDeployment();
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/deploy', { method: 'POST' });
+    expect(state.status).toBe('success');
+    expect(state.previewUrl).toBe('https://preview.example');
+    expect(store.deployDialogOpen.get()).toBe(false);
+  });
+
+  it('marks deployment as error when polling fails', async () => {
+    store.deploymentState.set({ status: 'queued', deploymentId: 'abc123', updatedAt: Date.now() });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('failed', { status: 500 })));
+
+    await store.pollDeploymentStatus();
+
+    const state = store.deploymentState.get();
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('failed');
+  });
+
+  it('polls until deployment succeeds when queued', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ deploymentId: 'abc123', status: 'queued' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'building' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: 'success', previewUrl: 'https://preview.example' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const initial = await store.requestDeployment();
+    expect(initial.status).toBe('queued');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(store.deploymentState.get().status).toBe('building');
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const finalState = store.deploymentState.get();
+
+    expect(finalState.status).toBe('success');
+    expect(finalState.previewUrl).toBe('https://preview.example');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/app/routes/__tests__/api.deploy.test.ts
+++ b/app/routes/__tests__/api.deploy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { action, loader } from '~/routes/api.deploy';
+
+const baseContext = {
+  cloudflare: {
+    env: {
+      DEPLOY_HOOK_URL: 'https://deploy.example/hook',
+      DEPLOY_STATUS_URL: 'https://deploy.example/status',
+      DEPLOY_STATUS_TOKEN: 'token-123',
+    },
+  },
+};
+
+describe('api.deploy route', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('triggers the deploy hook and returns normalized data', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'abc123', url: 'https://preview.example', status: 'success' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request('http://localhost/api/deploy', { method: 'POST' });
+    const response = await action({ request, context: baseContext as any, params: {} } as any);
+    const body = await response.json();
+
+    expect(fetchMock).toHaveBeenCalledWith('https://deploy.example/hook', { method: 'POST' });
+    expect(body).toEqual({ deploymentId: 'abc123', previewUrl: 'https://preview.example', status: 'success' });
+  });
+
+  it('returns an error when the deploy hook fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('failed', {
+          status: 500,
+          headers: { 'content-type': 'text/plain' },
+        }),
+      ),
+    );
+
+    const request = new Request('http://localhost/api/deploy', { method: 'POST' });
+    const response = await action({ request, context: baseContext as any, params: {} } as any);
+
+    expect(response.status).toBe(502);
+
+    const body = await response.json();
+    expect(body.error).toContain('Failed to trigger deployment');
+  });
+
+  it('fetches deployment status with authorization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ result: { id: 'abc123', status: 'success', preview_url: 'https://preview.example' } }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request('http://localhost/api/deploy?deploymentId=abc123');
+    const response = await loader({ request, context: baseContext as any, params: {} } as any);
+    const body = await response.json();
+
+    expect(fetchMock).toHaveBeenCalledWith('https://deploy.example/status/abc123', {
+      headers: { Authorization: 'Bearer token-123' },
+    });
+    expect(body).toEqual({ deploymentId: 'abc123', previewUrl: 'https://preview.example', status: 'success' });
+  });
+
+  it('returns 400 when deploymentId is missing', async () => {
+    const request = new Request('http://localhost/api/deploy');
+    const response = await loader({ request, context: baseContext as any, params: {} } as any);
+    expect(response.status).toBe(400);
+  });
+});

--- a/app/routes/api.deploy.ts
+++ b/app/routes/api.deploy.ts
@@ -1,0 +1,115 @@
+import { json, type ActionFunctionArgs, type LoaderFunctionArgs } from '@remix-run/cloudflare';
+import { normalizeExternalDeploymentPayload, type NormalizedDeploymentResponse } from '~/utils/deployment';
+
+export async function action({ context, request }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    return json({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  const { DEPLOY_HOOK_URL } = context.cloudflare.env;
+
+  if (!DEPLOY_HOOK_URL) {
+    return json({ error: 'Deploy hook is not configured' }, { status: 500 });
+  }
+
+  try {
+    const response = await fetch(DEPLOY_HOOK_URL, { method: 'POST' });
+
+    if (!response.ok) {
+      const message = await safeReadText(response);
+      return json({ error: 'Failed to trigger deployment', details: message }, { status: 502 });
+    }
+
+    const payload = await safeReadJson(response);
+    const normalized = normalizeExternalDeploymentPayload(payload);
+
+    const status = normalized.status ?? (normalized.previewUrl ? 'success' : 'queued');
+
+    const result: NormalizedDeploymentResponse = {
+      ...normalized,
+      status,
+    };
+
+    return json(result, { status: 200 });
+  } catch (error) {
+    console.error('Deployment hook failed', error);
+
+    return json({ error: 'Failed to trigger deployment' }, { status: 500 });
+  }
+}
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const deploymentId = url.searchParams.get('deploymentId');
+
+  if (!deploymentId) {
+    return json({ error: 'deploymentId is required' }, { status: 400 });
+  }
+
+  const { DEPLOY_STATUS_URL, DEPLOY_STATUS_TOKEN } = context.cloudflare.env;
+
+  if (!DEPLOY_STATUS_URL) {
+    return json({ error: 'Deployment status URL is not configured' }, { status: 500 });
+  }
+
+  const statusUrl = buildStatusUrl(DEPLOY_STATUS_URL, deploymentId);
+
+  try {
+    const response = await fetch(statusUrl, {
+      headers: DEPLOY_STATUS_TOKEN ? { Authorization: `Bearer ${DEPLOY_STATUS_TOKEN}` } : undefined,
+    });
+
+    if (!response.ok) {
+      const message = await safeReadText(response);
+      return json({ error: message || 'Failed to fetch deployment status' }, { status: response.status });
+    }
+
+    const payload = await safeReadJson(response);
+    const normalized = normalizeExternalDeploymentPayload(payload);
+
+    const status = normalized.status ?? 'queued';
+    const result: NormalizedDeploymentResponse = {
+      ...normalized,
+      deploymentId: normalized.deploymentId ?? deploymentId,
+      status,
+    };
+
+    return json(result, { status: 200 });
+  } catch (error) {
+    console.error('Failed to poll deployment status', error);
+
+    return json({ error: 'Failed to fetch deployment status' }, { status: 500 });
+  }
+}
+
+async function safeReadJson(response: Response) {
+  const contentType = response.headers.get('content-type');
+
+  if (contentType && contentType.toLowerCase().includes('application/json')) {
+    return response.json().catch(() => ({}));
+  }
+
+  const text = await response.text();
+
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+}
+
+async function safeReadText(response: Response) {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function buildStatusUrl(baseUrl: string, deploymentId: string) {
+  const url = new URL(baseUrl);
+  const normalizedPath = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
+  url.pathname = `${normalizedPath}/${encodeURIComponent(deploymentId)}`;
+
+  return url.toString();
+}

--- a/app/utils/deployment.ts
+++ b/app/utils/deployment.ts
@@ -1,0 +1,115 @@
+export type NormalizedDeploymentStatus = 'queued' | 'building' | 'success' | 'error';
+
+export interface NormalizedDeploymentResponse {
+  deploymentId?: string;
+  status?: NormalizedDeploymentStatus;
+  previewUrl?: string;
+  error?: string;
+}
+
+const statusAliases = new Map<string, NormalizedDeploymentStatus>([
+  ['queued', 'queued'],
+  ['pending', 'queued'],
+  ['waiting', 'queued'],
+  ['enqueued', 'queued'],
+  ['building', 'building'],
+  ['processing', 'building'],
+  ['in-progress', 'building'],
+  ['deploying', 'building'],
+  ['running', 'building'],
+  ['success', 'success'],
+  ['completed', 'success'],
+  ['finished', 'success'],
+  ['active', 'success'],
+  ['ready', 'success'],
+  ['live', 'success'],
+  ['error', 'error'],
+  ['failed', 'error'],
+  ['failure', 'error'],
+  ['canceled', 'error'],
+  ['cancelled', 'error'],
+]);
+
+export function mapExternalDeploymentStatus(value: unknown): NormalizedDeploymentStatus | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+
+  return statusAliases.get(normalized);
+}
+
+export function normalizeExternalDeploymentPayload(payload: unknown): NormalizedDeploymentResponse {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+
+  const candidates = collectCandidateObjects(payload);
+
+  const deploymentId = firstString(
+    candidates.flatMap((candidate) => [candidate.deploymentId, candidate.deployment_id, candidate.id]),
+  );
+
+  const previewUrl = firstString(
+    candidates.flatMap((candidate) => {
+      const aliases = Array.isArray(candidate.aliases) ? candidate.aliases : [];
+      return [
+        candidate.previewUrl,
+        candidate.preview_url,
+        candidate.url,
+        candidate.host,
+        candidate.preview,
+        ...aliases,
+      ];
+    }),
+  );
+
+  const status = candidates
+    .flatMap((candidate) => [candidate.status, candidate.state, candidate.stage?.status])
+    .map(mapExternalDeploymentStatus)
+    .find((value): value is NormalizedDeploymentStatus => Boolean(value));
+
+  const error = firstString(candidates.flatMap((candidate) => [candidate.error, candidate.message, candidate.reason]));
+
+  return {
+    deploymentId,
+    status,
+    previewUrl,
+    error,
+  };
+}
+
+export function shouldPollDeploymentStatus(status?: NormalizedDeploymentStatus) {
+  return status === 'queued' || status === 'building';
+}
+
+function collectCandidateObjects(payload: object) {
+  const candidates: Array<Record<string, any>> = [];
+
+  const push = (value: unknown) => {
+    if (value && typeof value === 'object') {
+      candidates.push(value as Record<string, any>);
+    }
+  };
+
+  push(payload);
+  push((payload as any).result);
+  push((payload as any).deployment);
+  push((payload as any).deployment_trigger);
+  push((payload as any).deploymentTrigger);
+  push((payload as any).deployment_stage);
+  push((payload as any).latest_stage);
+
+  return candidates;
+}
+
+function firstString(values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+
+  return undefined;
+}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1,3 +1,6 @@
 interface Env {
   ANTHROPIC_API_KEY: string;
+  DEPLOY_HOOK_URL?: string;
+  DEPLOY_STATUS_URL?: string;
+  DEPLOY_STATUS_TOKEN?: string;
 }


### PR DESCRIPTION
## Summary
- add deploy controls in the header with a modal and status banner for deployments
- manage deployment lifecycle in the workbench store and expose a Cloudflare deploy API route
- cover the flow with utility helpers plus unit tests for the store and API endpoints

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce684440bc832890db22e5c9b2e262