### PR TITLE
Fix chat streaming response handling

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -21,14 +21,18 @@ export type Messages = Message[];
 
 export type StreamingOptions = Omit<Parameters<typeof _streamText>[0], 'model'>;
 
-export type StreamTextResult = ReturnType<typeof _streamText> & {
+export type StreamTextResult = Awaited<ReturnType<typeof _streamText>> & {
   streamData: StreamData;
 };
 
-export function streamText(messages: Messages, env: Env, options?: StreamingOptions): StreamTextResult {
+export async function streamText(
+  messages: Messages,
+  env: Env,
+  options?: StreamingOptions,
+): Promise<StreamTextResult> {
   const streamData = new StreamData();
 
-  const result = _streamText({
+  const result = await _streamText({
     model: getAnthropicModel(getAPIKey(env)),
     system: getSystemPrompt(),
     maxTokens: MAX_TOKENS,

--- a/app/routes/api.chat.test.ts
+++ b/app/routes/api.chat.test.ts
@@ -11,12 +11,18 @@ vi.mock('~/lib/.server/llm/stream-text', () => ({
 beforeEach(() => {
   streamTextMock.mockReset();
   streamTextMock.mockResolvedValue({
-    toAIStream: () =>
-      new ReadableStream({
-        start(controller) {
-          controller.close();
-        },
-      }),
+    streamData: {
+      append: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    },
+    toDataStreamResponse: () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+      ),
   });
 });
 

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -94,7 +94,7 @@ export async function chatAction({ context, request }: ActionFunctionArgs) {
         },
       });
 
-      const response = result.toAIStreamResponse({ data: result.streamData });
+      const response = result.toDataStreamResponse({ data: result.streamData });
       const body = response.body;
 
       if (!body) {


### PR DESCRIPTION
## Summary
- ensure the Anthropic stream helper awaits the underlying streamText call and exposes stream data on the resolved result
- switch the chat route to use the current `toDataStreamResponse` helper when wiring streaming responses
- update the api chat action test double to provide the new streaming surface

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8043225c8328bff38610b694fba4