### PR TITLE
Adjust BaseChat React import

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -1,5 +1,5 @@
 import type { CompletionTokenUsage, Message } from 'ai';
-import React, { type RefCallback, useState } from 'react';
+import React, { useState, type RefCallback } from 'react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Menu } from '~/components/sidebar/Menu.client';
 import { IconButton } from '~/components/ui/IconButton';


### PR DESCRIPTION
## Summary
- adjust the BaseChat component's React import to destructure `useState` alongside the existing `RefCallback`

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cea3422fa8832892f7cd92c2607fa3