### PR TITLE
Add uncontrolled custom snippet dialog trigger

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -1,5 +1,5 @@
 import type { CompletionTokenUsage, Message } from 'ai';
-import React, { type RefCallback, useState } from 'react';
+import React, { type RefCallback } from 'react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Menu } from '~/components/sidebar/Menu.client';
 import { IconButton } from '~/components/ui/IconButton';
@@ -8,7 +8,7 @@ import { landingSnippetLibrary } from '~/lib/snippets/landing-snippets';
 import { classNames } from '~/utils/classNames';
 import { Messages } from './Messages.client';
 import { SendButton } from './SendButton.client';
-import { CustomSnippetDialog } from './CustomSnippetDialog';
+import { CustomSnippetDialog, CustomSnippetDialogTrigger } from './CustomSnippetDialog';
 import { TokenUsageSummary } from './TokenUsageSummary';
 
 import styles from './BaseChat.module.scss';
@@ -88,276 +88,273 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
     ref,
   ) => {
     const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
-    const [customSnippetOpen, setCustomSnippetOpen] = useState(false);
 
     return (
-      <div
-        ref={ref}
-        className={classNames(
-          styles.BaseChat,
-          'relative flex h-full w-full overflow-hidden bg-bolt-elements-background-depth-1',
-        )}
-        data-chat-visible={showChat}
-      >
-        <CustomSnippetDialog open={customSnippetOpen} onOpenChange={setCustomSnippetOpen} sendMessage={sendMessage} />
-        <ClientOnly>{() => <Menu />}</ClientOnly>
-        <div ref={scrollRef} className="flex overflow-y-auto w-full h-full">
-          <div className={classNames(styles.Chat, 'flex flex-col flex-grow min-w-[var(--chat-min-width)] h-full')}>
-            {!chatStarted && (
-              <div id="intro" className="mt-[18vh] max-w-[720px] mx-auto px-6">
-                <h1 className="text-5xl text-center font-bold text-bolt-elements-textPrimary mb-3 leading-tight">
-                  Launch cinematic landing pages in minutes
-                </h1>
-                <p className="mb-6 text-center text-bolt-elements-textSecondary text-lg">
-                  Pair your vision with Figplit’s taste. Prompt bespoke hero layouts, scroll choreography, and polished
-                  marketing flows without wrangling boilerplate.
-                </p>
-                <div className="mt-8 grid gap-3 text-left md:grid-cols-3">
-                  {FEATURE_CALLOUTS.map((callout) => (
-                    <div
-                      key={callout.title}
-                      className="rounded-2xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-2/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-bolt-elements-background-depth-2/40"
-                    >
-                      <div className="flex items-center gap-2 text-bolt-elements-item-contentAccent text-sm font-semibold">
-                        <div className={`${callout.icon} text-lg`} />
-                        {callout.title}
+      <CustomSnippetDialog sendMessage={sendMessage}>
+        <div
+          ref={ref}
+          className={classNames(
+            styles.BaseChat,
+            'relative flex h-full w-full overflow-hidden bg-bolt-elements-background-depth-1',
+          )}
+          data-chat-visible={showChat}
+        >
+          <ClientOnly>{() => <Menu />}</ClientOnly>
+          <div ref={scrollRef} className="flex overflow-y-auto w-full h-full">
+            <div className={classNames(styles.Chat, 'flex flex-col flex-grow min-w-[var(--chat-min-width)] h-full')}>
+              {!chatStarted && (
+                <div id="intro" className="mt-[18vh] max-w-[720px] mx-auto px-6">
+                  <h1 className="text-5xl text-center font-bold text-bolt-elements-textPrimary mb-3 leading-tight">
+                    Launch cinematic landing pages in minutes
+                  </h1>
+                  <p className="mb-6 text-center text-bolt-elements-textSecondary text-lg">
+                    Pair your vision with Figplit’s taste. Prompt bespoke hero layouts, scroll choreography, and
+                    polished marketing flows without wrangling boilerplate.
+                  </p>
+                  <div className="mt-8 grid gap-3 text-left md:grid-cols-3">
+                    {FEATURE_CALLOUTS.map((callout) => (
+                      <div
+                        key={callout.title}
+                        className="rounded-2xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-2/80 p-4 backdrop-blur supports-[backdrop-filter]:bg-bolt-elements-background-depth-2/40"
+                      >
+                        <div className="flex items-center gap-2 text-bolt-elements-item-contentAccent text-sm font-semibold">
+                          <div className={`${callout.icon} text-lg`} />
+                          {callout.title}
+                        </div>
+                        <p className="mt-2 text-sm text-bolt-elements-textSecondary leading-relaxed">
+                          {callout.description}
+                        </p>
                       </div>
-                      <p className="mt-2 text-sm text-bolt-elements-textSecondary leading-relaxed">
-                        {callout.description}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-                <div className="mt-10 text-left">
-                  <div className="flex items-center justify-between gap-4">
-                    <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-bolt-elements-textTertiary">
-                      Featured snippet starters
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => setCustomSnippetOpen(true)}
-                      className="inline-flex items-center gap-2 rounded-full border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.25em] text-bolt-elements-textSecondary transition-theme hover:border-bolt-elements-item-backgroundAccent hover:text-bolt-elements-textPrimary"
-                    >
-                      <span className="i-ph:magic-wand-duotone text-sm text-bolt-elements-item-contentAccent" />
-                      Custom lab
-                    </button>
+                    ))}
                   </div>
-                  <div className="mt-3 grid gap-3 md:grid-cols-3">
-                    {FEATURED_SNIPPETS.map((snippet) => (
-                      <button
-                        key={snippet.id}
-                        type="button"
-                        onClick={(event) => {
-                          sendMessage?.(event, snippet.prompt);
-                        }}
-                        className="group flex flex-col items-start gap-2 rounded-xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/80 p-4 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/20"
+                  <div className="mt-10 text-left">
+                    <div className="flex items-center justify-between gap-4">
+                      <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-bolt-elements-textTertiary">
+                        Featured snippet starters
+                      </h2>
+                      <CustomSnippetDialogTrigger
+                        disabled={isStreaming}
+                        className="inline-flex items-center gap-2 rounded-full border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/60 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.25em] text-bolt-elements-textSecondary transition-theme hover:border-bolt-elements-item-backgroundAccent hover:text-bolt-elements-textPrimary disabled:opacity-60 disabled:pointer-events-none"
+                      >
+                        <span className="i-ph:magic-wand-duotone text-sm text-bolt-elements-item-contentAccent" />
+                        Custom lab
+                      </CustomSnippetDialogTrigger>
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-3">
+                      {FEATURED_SNIPPETS.map((snippet) => (
+                        <button
+                          key={snippet.id}
+                          type="button"
+                          onClick={(event) => {
+                            sendMessage?.(event, snippet.prompt);
+                          }}
+                          className="group flex flex-col items-start gap-2 rounded-xl border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/80 p-4 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/20"
+                        >
+                          <div className="flex items-center gap-2 text-sm font-semibold text-bolt-elements-textPrimary">
+                            <div className="i-ph:shapes-duotone text-base text-bolt-elements-item-contentAccent group-hover:text-bolt-elements-item-contentAccent" />
+                            {snippet.title}
+                          </div>
+                          <p className="text-sm text-bolt-elements-textSecondary leading-relaxed">
+                            {snippet.description}
+                          </p>
+                          <div className="text-xs uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
+                            {snippet.bestFor.join(' • ')}
+                          </div>
+                        </button>
+                      ))}
+                      <CustomSnippetDialogTrigger
+                        disabled={isStreaming}
+                        className="group flex flex-col items-start gap-2 rounded-xl border border-dashed border-bolt-elements-borderColor/80 bg-bolt-elements-background-depth-1/40 p-4 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10 disabled:opacity-60 disabled:pointer-events-none"
                       >
                         <div className="flex items-center gap-2 text-sm font-semibold text-bolt-elements-textPrimary">
-                          <div className="i-ph:shapes-duotone text-base text-bolt-elements-item-contentAccent group-hover:text-bolt-elements-item-contentAccent" />
-                          {snippet.title}
+                          <div className="i-ph:magic-wand-duotone text-base text-bolt-elements-item-contentAccent group-hover:text-bolt-elements-item-contentAccent" />
+                          Custom animation lab
                         </div>
                         <p className="text-sm text-bolt-elements-textSecondary leading-relaxed">
-                          {snippet.description}
+                          Compose a bespoke motion snippet with Figplit and stage it for a specific section before
+                          merging.
                         </p>
                         <div className="text-xs uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
-                          {snippet.bestFor.join(' • ')}
+                          Targeted handoff
                         </div>
-                      </button>
-                    ))}
-                    <button
-                      type="button"
-                      onClick={() => setCustomSnippetOpen(true)}
-                      className="group flex flex-col items-start gap-2 rounded-xl border border-dashed border-bolt-elements-borderColor/80 bg-bolt-elements-background-depth-1/40 p-4 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10"
-                    >
-                      <div className="flex items-center gap-2 text-sm font-semibold text-bolt-elements-textPrimary">
-                        <div className="i-ph:magic-wand-duotone text-base text-bolt-elements-item-contentAccent group-hover:text-bolt-elements-item-contentAccent" />
-                        Custom animation lab
-                      </div>
-                      <p className="text-sm text-bolt-elements-textSecondary leading-relaxed">
-                        Compose a bespoke motion snippet with Figplit and stage it for a specific section before
-                        merging.
-                      </p>
-                      <div className="text-xs uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
-                        Targeted handoff
-                      </div>
-                    </button>
-                  </div>
-                  <p className="mt-3 text-xs text-bolt-elements-textTertiary">
-                    These live under <code className="font-semibold">/snippets</code>. Ask Figplit to remix them or{' '}
-                    click to seed a prompt with context.
-                  </p>
-                </div>
-              </div>
-            )}
-            <div
-              className={classNames('pt-6 px-6', {
-                'h-full flex flex-col': chatStarted,
-              })}
-            >
-              <ClientOnly>
-                {() => {
-                  return chatStarted ? (
-                    <Messages
-                      ref={messageRef}
-                      className="flex flex-col w-full flex-1 max-w-chat px-4 pb-6 mx-auto z-1"
-                      messages={messages}
-                      isStreaming={isStreaming}
-                      aborted={aborted}
-                    />
-                  ) : null;
-                }}
-              </ClientOnly>
-              {chatStarted ? (
-                <div className="mx-auto mt-4 w-full max-w-chat px-4">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.28em] text-bolt-elements-textTertiary">
-                    Snippet recommendations
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {SNIPPET_RECOMMENDATIONS.map((snippet) => (
-                      <button
-                        key={`recommendation-${snippet.id}`}
-                        type="button"
-                        onClick={(event) => {
-                          sendMessage?.(event, snippet.prompt);
-                        }}
-                        className="group flex min-w-[180px] flex-col items-start gap-1 rounded-lg border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/60 px-3 py-2 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10"
-                      >
-                        <span className="text-sm font-semibold text-bolt-elements-textPrimary group-hover:text-bolt-elements-item-contentAccent">
-                          {snippet.title}
-                        </span>
-                        {snippet.bestFor?.length ? (
-                          <span className="text-[11px] uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
-                            {snippet.bestFor.join(' • ')}
-                          </span>
-                        ) : null}
-                      </button>
-                    ))}
-                    <button
-                      type="button"
-                      onClick={() => setCustomSnippetOpen(true)}
-                      className="group flex min-w-[180px] flex-col items-start gap-1 rounded-lg border border-dashed border-bolt-elements-borderColor/80 bg-bolt-elements-background-depth-1/40 px-3 py-2 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10"
-                    >
-                      <span className="text-sm font-semibold text-bolt-elements-textPrimary group-hover:text-bolt-elements-item-contentAccent">
-                        Custom animation lab
-                      </span>
-                      <span className="text-[11px] uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
-                        Scoped deployment
-                      </span>
-                    </button>
+                      </CustomSnippetDialogTrigger>
+                    </div>
+                    <p className="mt-3 text-xs text-bolt-elements-textTertiary">
+                      These live under <code className="font-semibold">/snippets</code>. Ask Figplit to remix them or{' '}
+                      click to seed a prompt with context.
+                    </p>
                   </div>
                 </div>
-              ) : null}
+              )}
               <div
-                className={classNames('relative w-full max-w-chat mx-auto z-prompt', {
-                  'sticky bottom-0': chatStarted,
+                className={classNames('pt-6 px-6', {
+                  'h-full flex flex-col': chatStarted,
                 })}
               >
-                <div
-                  className={classNames(
-                    'shadow-sm border border-bolt-elements-borderColor bg-bolt-elements-prompt-background backdrop-filter backdrop-blur-[8px] rounded-lg overflow-hidden',
-                  )}
-                >
-                  <textarea
-                    ref={textareaRef}
-                    className={`w-full pl-4 pt-4 pr-16 focus:outline-none resize-none text-md text-bolt-elements-textPrimary placeholder-bolt-elements-textTertiary bg-transparent`}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        if (event.shiftKey) {
-                          return;
-                        }
-
-                        event.preventDefault();
-
-                        sendMessage?.(event);
-                      }
-                    }}
-                    value={input}
-                    onChange={(event) => {
-                      handleInputChange?.(event);
-                    }}
-                    style={{
-                      minHeight: TEXTAREA_MIN_HEIGHT,
-                      maxHeight: TEXTAREA_MAX_HEIGHT,
-                    }}
-                    placeholder="What landing page magic should Figplit design next?"
-                    translate="no"
-                  />
-                  <ClientOnly>
-                    {() => (
-                      <SendButton
-                        show={input.length > 0 || isStreaming}
+                <ClientOnly>
+                  {() => {
+                    return chatStarted ? (
+                      <Messages
+                        ref={messageRef}
+                        className="flex flex-col w-full flex-1 max-w-chat px-4 pb-6 mx-auto z-1"
+                        messages={messages}
                         isStreaming={isStreaming}
-                        onClick={(event) => {
-                          if (isStreaming) {
-                            handleStop?.();
+                        aborted={aborted}
+                      />
+                    ) : null;
+                  }}
+                </ClientOnly>
+                {chatStarted ? (
+                  <div className="mx-auto mt-4 w-full max-w-chat px-4">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.28em] text-bolt-elements-textTertiary">
+                      Snippet recommendations
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {SNIPPET_RECOMMENDATIONS.map((snippet) => (
+                        <button
+                          key={`recommendation-${snippet.id}`}
+                          type="button"
+                          onClick={(event) => {
+                            sendMessage?.(event, snippet.prompt);
+                          }}
+                          className="group flex min-w-[180px] flex-col items-start gap-1 rounded-lg border border-bolt-elements-borderColor/60 bg-bolt-elements-background-depth-1/60 px-3 py-2 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10"
+                        >
+                          <span className="text-sm font-semibold text-bolt-elements-textPrimary group-hover:text-bolt-elements-item-contentAccent">
+                            {snippet.title}
+                          </span>
+                          {snippet.bestFor?.length ? (
+                            <span className="text-[11px] uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
+                              {snippet.bestFor.join(' • ')}
+                            </span>
+                          ) : null}
+                        </button>
+                      ))}
+                      <CustomSnippetDialogTrigger
+                        disabled={isStreaming}
+                        className="group flex min-w-[180px] flex-col items-start gap-1 rounded-lg border border-dashed border-bolt-elements-borderColor/80 bg-bolt-elements-background-depth-1/40 px-3 py-2 text-left transition-theme hover:border-bolt-elements-item-backgroundAccent hover:bg-bolt-elements-item-backgroundAccent/10 disabled:opacity-60 disabled:pointer-events-none"
+                      >
+                        <span className="text-sm font-semibold text-bolt-elements-textPrimary group-hover:text-bolt-elements-item-contentAccent">
+                          Custom animation lab
+                        </span>
+                        <span className="text-[11px] uppercase tracking-[0.2em] text-bolt-elements-textTertiary">
+                          Scoped deployment
+                        </span>
+                      </CustomSnippetDialogTrigger>
+                    </div>
+                  </div>
+                ) : null}
+                <div
+                  className={classNames('relative w-full max-w-chat mx-auto z-prompt', {
+                    'sticky bottom-0': chatStarted,
+                  })}
+                >
+                  <div
+                    className={classNames(
+                      'shadow-sm border border-bolt-elements-borderColor bg-bolt-elements-prompt-background backdrop-filter backdrop-blur-[8px] rounded-lg overflow-hidden',
+                    )}
+                  >
+                    <textarea
+                      ref={textareaRef}
+                      className={`w-full pl-4 pt-4 pr-16 focus:outline-none resize-none text-md text-bolt-elements-textPrimary placeholder-bolt-elements-textTertiary bg-transparent`}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          if (event.shiftKey) {
                             return;
                           }
 
+                          event.preventDefault();
+
                           sendMessage?.(event);
-                        }}
-                      />
-                    )}
-                  </ClientOnly>
-                  <div className="flex flex-wrap justify-between gap-3 text-sm p-4 pt-2">
-                    <div className="flex flex-wrap items-center gap-3">
-                      <TokenUsageSummary usage={tokenUsage} limit={tokenLimit} />
-                      <IconButton
-                        title="Enhance prompt"
-                        disabled={input.length === 0 || enhancingPrompt}
-                        className={classNames({
-                          'opacity-100!': enhancingPrompt,
-                          'text-bolt-elements-item-contentAccent! pr-1.5 enabled:hover:bg-bolt-elements-item-backgroundAccent!':
-                            promptEnhanced,
-                        })}
-                        onClick={() => enhancePrompt?.()}
-                      >
-                        {enhancingPrompt ? (
-                          <>
-                            <div className="i-svg-spinners:90-ring-with-bg text-bolt-elements-loader-progress text-xl"></div>
-                            <div className="ml-1.5">Enhancing prompt...</div>
-                          </>
-                        ) : (
-                          <>
-                            <div className="i-bolt:stars text-xl"></div>
-                            {promptEnhanced && <div className="ml-1.5">Prompt enhanced</div>}
-                          </>
-                        )}
-                      </IconButton>
-                    </div>
-                    {input.length > 3 ? (
-                      <div className="text-xs text-bolt-elements-textTertiary">
-                        Use <kbd className="kdb">Shift</kbd> + <kbd className="kdb">Return</kbd> for a new line
+                        }
+                      }}
+                      value={input}
+                      onChange={(event) => {
+                        handleInputChange?.(event);
+                      }}
+                      style={{
+                        minHeight: TEXTAREA_MIN_HEIGHT,
+                        maxHeight: TEXTAREA_MAX_HEIGHT,
+                      }}
+                      placeholder="What landing page magic should Figplit design next?"
+                      translate="no"
+                    />
+                    <ClientOnly>
+                      {() => (
+                        <SendButton
+                          show={input.length > 0 || isStreaming}
+                          isStreaming={isStreaming}
+                          onClick={(event) => {
+                            if (isStreaming) {
+                              handleStop?.();
+                              return;
+                            }
+
+                            sendMessage?.(event);
+                          }}
+                        />
+                      )}
+                    </ClientOnly>
+                    <div className="flex flex-wrap justify-between gap-3 text-sm p-4 pt-2">
+                      <div className="flex flex-wrap items-center gap-3">
+                        <TokenUsageSummary usage={tokenUsage} limit={tokenLimit} />
+                        <IconButton
+                          title="Enhance prompt"
+                          disabled={input.length === 0 || enhancingPrompt}
+                          className={classNames({
+                            'opacity-100!': enhancingPrompt,
+                            'text-bolt-elements-item-contentAccent! pr-1.5 enabled:hover:bg-bolt-elements-item-backgroundAccent!':
+                              promptEnhanced,
+                          })}
+                          onClick={() => enhancePrompt?.()}
+                        >
+                          {enhancingPrompt ? (
+                            <>
+                              <div className="i-svg-spinners:90-ring-with-bg text-bolt-elements-loader-progress text-xl"></div>
+                              <div className="ml-1.5">Enhancing prompt...</div>
+                            </>
+                          ) : (
+                            <>
+                              <div className="i-bolt:stars text-xl"></div>
+                              {promptEnhanced && <div className="ml-1.5">Prompt enhanced</div>}
+                            </>
+                          )}
+                        </IconButton>
                       </div>
-                    ) : null}
+                      {input.length > 3 ? (
+                        <div className="text-xs text-bolt-elements-textTertiary">
+                          Use <kbd className="kdb">Shift</kbd> + <kbd className="kdb">Return</kbd> for a new line
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="bg-bolt-elements-background-depth-1 pb-6">{/* Ghost Element */}</div>
+                </div>
+              </div>
+              {!chatStarted && (
+                <div id="examples" className="relative w-full max-w-xl mx-auto mt-8 flex justify-center">
+                  <div className="flex flex-col space-y-2 [mask-image:linear-gradient(to_bottom,black_0%,transparent_180%)] hover:[mask-image:none]">
+                    {EXAMPLE_PROMPTS.map((examplePrompt, index) => {
+                      return (
+                        <button
+                          key={index}
+                          onClick={(event) => {
+                            sendMessage?.(event, examplePrompt.text);
+                          }}
+                          className="group flex items-center w-full gap-2 justify-center bg-transparent text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary transition-theme"
+                        >
+                          {examplePrompt.text}
+                          <div className="i-ph:arrow-bend-down-left" />
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
-                <div className="bg-bolt-elements-background-depth-1 pb-6">{/* Ghost Element */}</div>
-              </div>
+              )}
             </div>
-            {!chatStarted && (
-              <div id="examples" className="relative w-full max-w-xl mx-auto mt-8 flex justify-center">
-                <div className="flex flex-col space-y-2 [mask-image:linear-gradient(to_bottom,black_0%,transparent_180%)] hover:[mask-image:none]">
-                  {EXAMPLE_PROMPTS.map((examplePrompt, index) => {
-                    return (
-                      <button
-                        key={index}
-                        onClick={(event) => {
-                          sendMessage?.(event, examplePrompt.text);
-                        }}
-                        className="group flex items-center w-full gap-2 justify-center bg-transparent text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary transition-theme"
-                      >
-                        {examplePrompt.text}
-                        <div className="i-ph:arrow-bend-down-left" />
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
+            <ClientOnly>{() => <Workbench chatStarted={chatStarted} isStreaming={isStreaming} />}</ClientOnly>
           </div>
-          <ClientOnly>{() => <Workbench chatStarted={chatStarted} isStreaming={isStreaming} />}</ClientOnly>
         </div>
-      </div>
+      </CustomSnippetDialog>
     );
   },
 );


### PR DESCRIPTION
## Summary
- allow `CustomSnippetDialog` to manage its own open state and expose a reusable trigger component
- reset dialog state when it closes and support disabling triggers while streaming
- update the chat quick actions to use the new trigger API instead of manual state management

## Testing
- pnpm typecheck
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cea365d7ac8328a169208ea9a0479c