### PR TITLE
Add chat context limiter with forkable thread workflow

### DIFF
--- a/app/components/chat/SendButton.client.tsx
+++ b/app/components/chat/SendButton.client.tsx
@@ -1,25 +1,36 @@
 import { AnimatePresence, cubicBezier, motion } from 'framer-motion';
 
+import { classNames } from '~/utils/classNames';
+
 interface SendButtonProps {
   show: boolean;
   isStreaming?: boolean;
+  disabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
 const customEasingFn = cubicBezier(0.4, 0, 0.2, 1);
 
-export function SendButton({ show, isStreaming, onClick }: SendButtonProps) {
+export function SendButton({ show, isStreaming, disabled = false, onClick }: SendButtonProps) {
   return (
     <AnimatePresence>
       {show ? (
         <motion.button
-          className="absolute flex justify-center items-center top-[18px] right-[22px] p-1 bg-accent-500 hover:brightness-94 color-white rounded-md w-[34px] h-[34px] transition-theme"
+          className={classNames(
+            'absolute flex justify-center items-center top-[18px] right-[22px] p-1 bg-accent-500 hover:brightness-94 color-white rounded-md w-[34px] h-[34px] transition-theme',
+            disabled && 'cursor-not-allowed opacity-60 hover:brightness-100',
+          )}
           transition={{ ease: customEasingFn, duration: 0.17 }}
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 10 }}
+          disabled={disabled}
           onClick={(event) => {
             event.preventDefault();
+            if (disabled) {
+              return;
+            }
+
             onClick?.(event);
           }}
         >

--- a/app/utils/context-limit.ts
+++ b/app/utils/context-limit.ts
@@ -1,0 +1,40 @@
+import type { Message } from 'ai';
+
+const AVG_CHARS_PER_TOKEN = 4;
+const MESSAGE_OVERHEAD = 6;
+
+function toContentString(content: Message['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+
+        if (part && typeof part === 'object' && 'text' in part && typeof part.text === 'string') {
+          return part.text;
+        }
+
+        return '';
+      })
+      .join(' ');
+  }
+
+  if (content && typeof content === 'object' && 'text' in content && typeof content.text === 'string') {
+    return content.text;
+  }
+
+  return '';
+}
+
+export function estimateMessageTokens(messages: Message[]): number {
+  return messages.reduce((total, message) => {
+    const content = toContentString(message.content);
+    const contentTokens = Math.ceil(content.length / AVG_CHARS_PER_TOKEN);
+    return total + contentTokens + MESSAGE_OVERHEAD;
+  }, 0);
+}

--- a/app/utils/fork-summary.ts
+++ b/app/utils/fork-summary.ts
@@ -1,0 +1,66 @@
+import type { ArtifactState } from '~/lib/stores/workbench';
+import { WORK_DIR } from './constants';
+
+interface ChangedFileSummary {
+  path: string;
+  isBinary: boolean;
+}
+
+interface ForkSummaryInput {
+  artifacts: ArtifactState[];
+  changedFiles: ChangedFileSummary[];
+  originalUrlId?: string;
+}
+
+export interface ForkSummaryResult {
+  displayText: string;
+  message: string;
+  description: string;
+}
+
+export function createForkSummary({ artifacts, changedFiles, originalUrlId }: ForkSummaryInput): ForkSummaryResult {
+  const artifactItems = Array.from(
+    new Set(
+      artifacts
+        .map((artifact) => artifact.title?.trim())
+        .filter((title): title is string => Boolean(title)),
+    ),
+  );
+
+  const fileItems = changedFiles.map((file) => {
+    const relativePath = toRelativePath(file.path);
+    return file.isBinary ? `Binary asset updated: ${relativePath}` : `Updated ${relativePath}`;
+  });
+
+  const bulletItems = [...artifactItems, ...fileItems];
+
+  if (bulletItems.length === 0) {
+    bulletItems.push('No tracked Figplit artifacts or file deltas were found.');
+  }
+
+  const displayText = bulletItems.map((item) => `• ${item}`).join('\n');
+
+  const summaryHeader = originalUrlId
+    ? `Forked from Figplit chat ${originalUrlId}.`
+    : 'Forked from the previous Figplit conversation.';
+
+  const bulletBlock = bulletItems.map((item) => `- ${item}`).join('\n');
+
+  const message = `${summaryHeader}\n\nSummary of changes so far:\n${bulletBlock}\n\nPlease continue iterating from here with this context.`;
+
+  const description = artifactItems[0] ?? 'Forked Figplit session';
+
+  return { displayText, message, description };
+}
+
+function toRelativePath(path: string) {
+  if (path.startsWith(`${WORK_DIR}/`)) {
+    return path.slice(WORK_DIR.length + 1);
+  }
+
+  if (path.startsWith(WORK_DIR)) {
+    return path.slice(WORK_DIR.length);
+  }
+
+  return path;
+}


### PR DESCRIPTION
## Summary
- monitor total chat tokens to warn when the conversation nears the model context limit and block further prompts once exceeded
- surface UI messaging with a fork action that creates a new chat seeded with a summary of carried-over work
- add helpers for estimating message tokens and compiling fork summaries while extending persistence to create new chat entries

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cebef77a7c8328b1b9e9c837f17475